### PR TITLE
:recycle: refactor[Nemu]: standardize method naming conventions

### DIFF
--- a/src/core/Bus.cpp
+++ b/src/core/Bus.cpp
@@ -5,7 +5,7 @@ Bus::Bus() {
     ram.fill(0x00);
 
     // Connect CPU to this bus
-    cpu.ConnectBus(this);
+    cpu.connect_bus(this);
 }
 
 Bus::~Bus() = default;

--- a/src/core/RP2A03.h
+++ b/src/core/RP2A03.h
@@ -37,8 +37,8 @@ public:
     constexpr static uint16_t NMI_VECTOR{0xFFFA};      // Non-maskable interrupt vector is located at 0xFFFA and 0xFFFB
     constexpr static uint16_t IRQ_VECTOR{0xFFFE};      // Interrupt request vector is located at 0xFFFE and 0xFFFF
 
-    void ConnectBus(Bus* n) { bus = n; }
-    const auto& getLookup() const noexcept { return lookup; }
+    void connect_bus(Bus* n) { bus = n; }
+    const auto& get_lookup() const noexcept { return lookup; }
 
     enum class DEBUG_MNEMONIC : uint8_t {
         ADC, AND, ASL, 

--- a/src/utils/Disassembler.cpp
+++ b/src/utils/Disassembler.cpp
@@ -1,14 +1,13 @@
 #include "Disassembler.h"
 
+#include <cstdint>
+
 #include "../core/Bus.h"
 #include "../core/RP2A03.h"
 
-#include <cstdint>
-
-Disassembler::Disassembler(Bus* bus,
-    const std::span<const RP2A03::INSTRUCTION, 256> lookup)
-    : bus(bus), lookup(lookup) {
-}
+Disassembler::Disassembler(
+    Bus* bus, const std::span<const RP2A03::INSTRUCTION, 256> lookup)
+    : bus(bus), lookup(lookup) {}
 
 uint8_t Disassembler::read(uint16_t addr) const noexcept {
     return bus->read(addr, true);
@@ -21,25 +20,26 @@ Disassembler::DisasmLine Disassembler::disassemble(uint16_t addr) const {
     const auto& instr = lookup[line.opcode];
     line.mnemonic = instr.debug_mnemonic;
     line.addrmode = instr.debug_addrmode;
-    line.len = instrLen(line.addrmode);
+    line.len = instr_len(line.addrmode);
     for (size_t i = 0; i < line.len; i++) {
         line.bytes[i] = read(addr + i);
     }
     line.next = static_cast<uint16_t>(addr + line.len);
 
-    line.text = format(line); // Format the disassembly text (e.g. "LDA #$01")
+    line.text = format(line);  // Format the disassembly text (e.g. "LDA #$01")
 
     return line;
 }
 
-std::vector<Disassembler::DisasmLine> Disassembler::disassemble(uint16_t start, size_t count) const {
+std::vector<Disassembler::DisasmLine> Disassembler::disassemble(
+    uint16_t start, size_t count) const {
     std::vector<DisasmLine> lines;
     lines.reserve(count);
 
     uint16_t addr = start;
     for (size_t i = 0; i < count; i++) {
         auto line = disassemble(addr);
-        addr = line.next; // Move to the next instruction address
+        addr = line.next;  // Move to the next instruction address
         lines.push_back(std::move(line));
     }
     return lines;
@@ -77,23 +77,23 @@ std::string Disassembler::format(const DisasmLine& line) const {
         case AM::IMM:
             // e.g. "LDA #$01"
             operand.push_back('#');
-            appendDollarHex8(operand, op1);
+            append_dollar_hex_8(operand, op1);
             break;
 
         case AM::ZP0:
             // e.g. "LDA $02"
-            appendDollarHex8(operand, op1);
+            append_dollar_hex_8(operand, op1);
             break;
 
         case AM::ZPX:
             // e.g. "LDA $02,X"
-            appendDollarHex8(operand, op1);
+            append_dollar_hex_8(operand, op1);
             operand.append(",X");
             break;
 
         case AM::ZPY:
             // e.g. "LDA $02,Y"
-            appendDollarHex8(operand, op1);
+            append_dollar_hex_8(operand, op1);
             operand.append(",Y");
             break;
 
@@ -101,7 +101,7 @@ std::string Disassembler::format(const DisasmLine& line) const {
             // e.g. "JMP $1234"
             const uint16_t a =
                 static_cast<uint16_t>(op1) | (static_cast<uint16_t>(op2) << 8);
-            appendDollarHex16(operand, a);
+            append_dollar_hex_16(operand, a);
             break;
         }
 
@@ -109,7 +109,7 @@ std::string Disassembler::format(const DisasmLine& line) const {
             // e.g. "LDA $1234,X"
             const uint16_t a =
                 static_cast<uint16_t>(op1) | (static_cast<uint16_t>(op2) << 8);
-            appendDollarHex16(operand, a);
+            append_dollar_hex_16(operand, a);
             operand.append(",X");
             break;
         }
@@ -118,7 +118,7 @@ std::string Disassembler::format(const DisasmLine& line) const {
             // e.g. "LDA $1234,Y"
             const uint16_t a =
                 static_cast<uint16_t>(op1) | (static_cast<uint16_t>(op2) << 8);
-            appendDollarHex16(operand, a);
+            append_dollar_hex_16(operand, a);
             operand.append(",Y");
             break;
         }
@@ -128,7 +128,7 @@ std::string Disassembler::format(const DisasmLine& line) const {
             const uint16_t a =
                 static_cast<uint16_t>(op1) | (static_cast<uint16_t>(op2) << 8);
             operand.push_back('(');
-            appendDollarHex16(operand, a);
+            append_dollar_hex_16(operand, a);
             operand.push_back(')');
             break;
         }
@@ -136,25 +136,25 @@ std::string Disassembler::format(const DisasmLine& line) const {
         case AM::IZX:
             // e.g. "LDA ($20,X)"
             operand.push_back('(');
-            appendDollarHex8(operand, op1);
+            append_dollar_hex_8(operand, op1);
             operand.append(",X)");
             break;
 
         case AM::IZY:
             // e.g. "LDA ($20),Y"
             operand.push_back('(');
-            appendDollarHex8(operand, op1);
+            append_dollar_hex_8(operand, op1);
             operand.append("),Y");
             break;
 
         case AM::REL: {
             // e.g. "BEQ $1234" (branch target)
-            // The operand is a signed offset from the next instruction address (line.next)
-            // branch target = line.next + signed offset
+            // The operand is a signed offset from the next instruction address
+            // (line.next) branch target = line.next + signed offset
             const int8_t rel = static_cast<int8_t>(op1);
             const uint16_t target =
                 static_cast<uint16_t>(static_cast<int16_t>(line.next) + rel);
-            appendDollarHex16(operand, target);
+            append_dollar_hex_16(operand, target);
             break;
         }
 

--- a/src/utils/Disassembler.h
+++ b/src/utils/Disassembler.h
@@ -11,7 +11,7 @@
 #include "../core/RP2A03.h"
 
 class Disassembler {
-public:
+   public:
     explicit Disassembler(
         Bus* bus, const std::span<const RP2A03::INSTRUCTION, 256> lookup);
     ~Disassembler() = default;
@@ -20,23 +20,24 @@ public:
         uint16_t addr{0x0000};  // instruction address
         uint8_t opcode{0x00};   // opcode byte
         uint8_t len{0};         // instruction length in bytes
-        std::array<uint8_t, 3> bytes{{0, 0, 0}};   // Original bytes of the instruction (up to 3 bytes)
+        std::array<uint8_t, 3> bytes{
+            {0, 0, 0}};  // Original bytes of the instruction (up to 3 bytes)
 
         uint16_t next{0x0000};  // addr + len
 
-        std::string text;       // Formatted disassembly text (e.g. "LDA #$01")
+        std::string text;  // Formatted disassembly text (e.g. "LDA #$01")
 
         RP2A03::DEBUG_MNEMONIC mnemonic{};
         RP2A03::DEBUG_ADDRESSING_MODE addrmode{};
     };
 
-    static constexpr uint8_t instrLen(
+    static constexpr uint8_t instr_len(
         RP2A03::DEBUG_ADDRESSING_MODE m) noexcept {
         using M = RP2A03::DEBUG_ADDRESSING_MODE;
         switch (m) {
             case M::IMP:
             case M::ACC:
-                return 1; // e.g. "CLC" or "ASL A"
+                return 1;  // e.g. "CLC" or "ASL A"
 
             case M::IMM:
             case M::ZP0:
@@ -45,7 +46,7 @@ public:
             case M::REL:
             case M::IZX:
             case M::IZY:
-                return 2; // e.g. "LDA #$01" or "STA $02,X"
+                return 2;  // e.g. "LDA #$01" or "STA $02,X"
 
             case M::ABS:
             case M::ABX:
@@ -54,53 +55,54 @@ public:
                 return 3;  // e.g. "JMP $1234" or "LDA $1234,Y"
 
             default:
-                return 1; // Unknown/invalid addressing mode
-                // Treat as opcode-only to ensure forward progress
+                return 1;  // Unknown/invalid addressing mode
+                           // Treat as opcode-only to ensure forward progress
         }
     }
 
-public:
+   public:
     std::vector<DisasmLine> disassemble(uint16_t start, size_t count) const;
     DisasmLine disassemble(uint16_t addr) const;
 
-    // Format the disassembly text based on the instruction and its addressing mode
+    // Format the disassembly text based on the instruction and its addressing
+    // mode
     std::string format(const DisasmLine& line) const;
 
     // Helper functions to format hexadecimal values
-    static inline void appendHex8(std::string& out, uint8_t v) {
+    static inline void append_hex_8(std::string& out, uint8_t v) {
         static constexpr char hex[] = "0123456789ABCDEF";
         out.push_back(hex[(v >> 4) & 0x0F]);
         out.push_back(hex[v & 0x0F]);
     }
 
-    static inline void appendHex16(std::string& out, uint16_t v) {
-        appendHex8(out, static_cast<uint8_t>((v >> 8) & 0xFF));
-        appendHex8(out, static_cast<uint8_t>(v & 0xFF));
+    static inline void append_hex_16(std::string& out, uint16_t v) {
+        append_hex_8(out, static_cast<uint8_t>((v >> 8) & 0xFF));
+        append_hex_8(out, static_cast<uint8_t>(v & 0xFF));
     }
 
-    static inline void appendDollarHex8(std::string& out, uint8_t v) {
+    static inline void append_dollar_hex_8(std::string& out, uint8_t v) {
         out.push_back('$');
-        appendHex8(out, v);
+        append_hex_8(out, v);
     }
 
-    static inline void appendDollarHex16(std::string& out, uint16_t v) {
+    static inline void append_dollar_hex_16(std::string& out, uint16_t v) {
         out.push_back('$');
-        appendHex16(out, v);
+        append_hex_16(out, v);
     }
 
-private:
+   private:
     Bus* bus;
     const std::span<const RP2A03::INSTRUCTION, 256> lookup;
 
-    static constexpr std::array<std::string_view, static_cast<size_t>(RP2A03::DEBUG_MNEMONIC::COUNT)> 
-    mnemonics {
-        "ADC", "AND", "ASL", "BCC", "BCS", "BEQ", "BIT", "BMI", "BNE", "BPL",
-        "BRK", "BVC", "BVS", "CLC", "CLD", "CLI", "CLV", "CMP", "CPX", "CPY",
-        "DEC", "DEX", "DEY", "EOR", "INC", "INX", "INY", "JMP", "JSR", "LDA",
-        "LDX", "LDY", "LSR", "NOP", "ORA", "PHA", "PHP", "PLA", "PLP", "ROL",
-        "ROR", "RTI", "RTS", "SBC", "SEC", "SED", "SEI", "STA", "STX", "STY",
-        "TAX", "TAY", "TSX", "TXA", "TXS", "TYA", "XXX"
-    };
+    static constexpr std::array<
+        std::string_view, static_cast<size_t>(RP2A03::DEBUG_MNEMONIC::COUNT)>
+        mnemonics{"ADC", "AND", "ASL", "BCC", "BCS", "BEQ", "BIT", "BMI", "BNE",
+                  "BPL", "BRK", "BVC", "BVS", "CLC", "CLD", "CLI", "CLV", "CMP",
+                  "CPX", "CPY", "DEC", "DEX", "DEY", "EOR", "INC", "INX", "INY",
+                  "JMP", "JSR", "LDA", "LDX", "LDY", "LSR", "NOP", "ORA", "PHA",
+                  "PHP", "PLA", "PLP", "ROL", "ROR", "RTI", "RTS", "SBC", "SEC",
+                  "SED", "SEI", "STA", "STX", "STY", "TAX", "TAY", "TSX", "TXA",
+                  "TXS", "TYA", "XXX"};
 
     uint8_t read(uint16_t addr) const noexcept;
 };

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -9,11 +9,11 @@ TEST_CASE("Basic test", "[utils]") {
     Bus bus;
 
     // Write some test data to the bus
-    bus.write(0x0000, 0xA9); // LDA Immediate opcode
-    bus.write(0x0001, 0x01); // Operand for LDA
+    bus.write(0x0000, 0xA9);  // LDA Immediate opcode
+    bus.write(0x0001, 0x01);  // Operand for LDA
 
     // Create a disassembler instance
-    Disassembler disasm(&bus, bus.cpu.getLookup());
+    Disassembler disasm(&bus, bus.cpu.get_lookup());
 
     // Disassemble the instruction at address 0x0000
     auto line = disasm.disassemble(0x0000);


### PR DESCRIPTION
This pull request focuses on standardizing naming conventions to use snake_case for method and helper function names, improving code readability and consistency across the codebase. It also includes minor formatting and style changes for better maintainability.

### Naming Convention Updates

* Renamed all public and private methods in `Disassembler` and `RP2A03` classes from camelCase to snake_case (e.g., `ConnectBus` to `connect_bus`, `getLookup` to `get_lookup`, `instrLen` to `instr_len`, and all `appendHex*`/`appendDollarHex*` helpers to `append_hex_*`/`append_dollar_hex_*`). [[1]](diffhunk://#diff-21ee0b2c5ce28f427f9ff194a47cf078315ba0e9a92c1dab220ae23a040feeb2L40-R41) [[2]](diffhunk://#diff-aa9470a195cf1559b74d4cd4cb8d89e5dbaa38955c12db6fe10707bd4883db72L24-R23) [[3]](diffhunk://#diff-67de1eaa493fc6f0cd5920f82f8d6685e86cb5034687c703f8fbd75146082f39L33-R34) [[4]](diffhunk://#diff-67de1eaa493fc6f0cd5920f82f8d6685e86cb5034687c703f8fbd75146082f39L66-R105)
* Updated all call sites to use the new snake_case method names, including in `Bus.cpp`, `Disassembler.cpp`, and test code. [[1]](diffhunk://#diff-5612c2273846adac8abfeb6c77d73d6930461f92099df88fbf70edebfcd8d0c9L8-R8) [[2]](diffhunk://#diff-aa9470a195cf1559b74d4cd4cb8d89e5dbaa38955c12db6fe10707bd4883db72L24-R23) [[3]](diffhunk://#diff-5ecab8a6f0df02a6e02285a6ab6672138b8bde60ea0d6c24aa2d4267a666defeL16-R16)

### Code Formatting and Style

* Reformatted code for improved readability, such as breaking long lines, adjusting brace placement, and cleaning up constructor formatting. [[1]](diffhunk://#diff-aa9470a195cf1559b74d4cd4cb8d89e5dbaa38955c12db6fe10707bd4883db72R3-R10) [[2]](diffhunk://#diff-67de1eaa493fc6f0cd5920f82f8d6685e86cb5034687c703f8fbd75146082f39L23-R24)
* Updated comments for clarity and consistency with the new formatting style. [[1]](diffhunk://#diff-aa9470a195cf1559b74d4cd4cb8d89e5dbaa38955c12db6fe10707bd4883db72L131-R157) [[2]](diffhunk://#diff-67de1eaa493fc6f0cd5920f82f8d6685e86cb5034687c703f8fbd75146082f39L66-R105)

### No Functional Changes

* All changes are non-functional and do not affect program behavior; they are strictly related to naming, formatting, and style. (all references above)