### PR TITLE
Refactor flag handling in RP2A03 and update Catch2 version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ include(FetchContent)
 FetchContent_Declare(
     Catch2
     GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-    GIT_TAG v3.5.2
+    GIT_TAG v3.14.0
 )
 
 option(NEMU_ENABLE_TESTS "Enable unit tests" ON) # Turn off with -DNEMU_ENABLE_TESTS=OFF

--- a/src/core/Bus.h
+++ b/src/core/Bus.h
@@ -10,11 +10,11 @@ public:
     Bus();
     ~Bus();
 
-public: // Devices on the bus
+public:  // Devices on the bus
     RP2A03 cpu;
     std::array<uint8_t, 64 * 1024> ram;
 
 public:
     void write(uint16_t addr, uint8_t data) noexcept;
-    uint8_t read(uint16_t addr, bool bReadOnly = false) noexcept;
+    uint8_t read(uint16_t addr, bool bus_read_only = false) noexcept;
 };

--- a/src/core/RP2A03.cpp
+++ b/src/core/RP2A03.cpp
@@ -42,8 +42,8 @@ inline void RP2A03::write(uint16_t addr, uint8_t data) noexcept {
     bus->write(addr, data);
 }
 
-inline uint8_t RP2A03::GetFlag(FLAGS6502 flag) const noexcept { return (status & flag) > 0 ? 1 : 0; }
-inline void RP2A03::SetFlag(FLAGS6502 flag, bool value) noexcept {
+inline uint8_t RP2A03::get_flag(FLAGS6502 flag) const noexcept { return (status & flag) > 0 ? 1 : 0; }
+inline void RP2A03::Set_flag(FLAGS6502 flag, bool value) noexcept {
     if (value) {
         status |= flag;
     } else {
@@ -81,12 +81,11 @@ void RP2A03::reset() {
     a = 0;
     x = 0;
     y = 0;
-    sp = 0xFD;          // Stack Pointer starts at 0xFD after reset
-    status = 0x00 | U | I;  // Clear all flags except for the unused flag and
-                            // the interrupt disable flag, which are set after reset
+    sp = 0xFD;                // Stack Pointer starts at 0xFD after reset
+    status = 0x00 | U | I;    // Clear all flags except for the unused flag and
+                              // the interrupt disable flag, which are set after reset
 
-    addr_abs =
-        RESET_VECTOR;  // The reset vector is located at 0xFFFC and 0xFFFD
+    addr_abs = RESET_VECTOR;  // The reset vector is located at 0xFFFC and 0xFFFD
     uint16_t lo = read(addr_abs + 0);  // Read the low byte of the reset vector
     uint16_t hi = read(addr_abs + 1);  // Read the high byte of the reset vector
 
@@ -105,33 +104,26 @@ void RP2A03::irq() {
     // This is a maskable interrupt, meaning it can be ignored if the Interrupt
     // Disable flag is set
 
-    if (GetFlag(I) == 0) {  // Only process the interrupt if the Interrupt
-                            // Disable flag is clear
-        write(STACK_BASE + sp,
-              (pc >> 8) & 0x00FF);  // Push the high byte of the program counter
-                                    // onto the stack
-        sp--;
-        write(STACK_BASE + sp, pc & 0x00FF);  // Push the low byte of the
-                                              // program counter onto the stack
-        sp--;
+    if (get_flag(I) == 0) {  // Only process the interrupt if the Interrupt Disable flag is clear
+        write(STACK_BASE + sp, (pc >> 8) & 0x00FF);
+        sp--;  // Push the high byte of the program counter onto the stack
+
+        write(STACK_BASE + sp, pc & 0x00FF);
+        sp--;  // Push the low byte of the program counter onto the stack
 
         // When an interrupt occurs, the processor automatically pushes the
         // current program counter and status register onto the stack
-        SetFlag(B, 0);
-        SetFlag(U, 1);
-        SetFlag(I, 1);  // Disable further interrupts
-        write(STACK_BASE + sp,
-              status);  // Push the processor status onto the stack
+        Set_flag(B, 0);
+        Set_flag(U, 1);
+        Set_flag(I, 1);  // Disable further interrupts
+        write(STACK_BASE + sp, status);  // Push the processor status onto the stack
         sp--;
 
-        addr_abs =
-            IRQ_VECTOR;  // The interrupt vector is located at 0xFFFE and 0xFFFF
-        uint16_t lo =
-            read(addr_abs + 0);  // Read the low byte of the interrupt vector
-        uint16_t hi =
-            read(addr_abs + 1);  // Read the high byte of the interrupt vector
-        pc = (hi << 8) | lo;     // Set the program counter to the address
-                                 // specified by the interrupt vector
+        addr_abs = IRQ_VECTOR;  // The interrupt vector is located at 0xFFFE and 0xFFFF
+        uint16_t lo = read(addr_abs + 0);  // Read the low byte of the interrupt vector
+        uint16_t hi = read(addr_abs + 1);  // Read the high byte of the interrupt vector
+        pc = (hi << 8) | lo;  // Set the program counter to the address
+                              // specified by the interrupt vector
 
         cycles = 7;  // IRQ takes time to complete, 7 cycles?
     }
@@ -141,30 +133,22 @@ void RP2A03::nmi() {
     // Non-Maskable Interrupt (NMI)
     // This interrupt cannot be ignored and will always be processed
 
-    write(STACK_BASE + sp,
-          (pc >> 8) & 0x00FF);  // Push the high byte of the program counter
-                                // onto the stack
-    sp--;
-    write(
-        STACK_BASE + sp,
-        pc &
-            0x00FF);  // Push the low byte of the program counter onto the stack
-    sp--;
+    write(STACK_BASE + sp, (pc >> 8) & 0x00FF);  // Push the high byte of the program counter
+    sp--;                                        // onto the stack
 
-    SetFlag(B, 0);
-    SetFlag(U, 1);
-    SetFlag(I, 1);                   // Disable further interrupts
+    write(STACK_BASE + sp, pc & 0x00FF);  // Push the low byte of the program counter
+    sp--;                                 // onto the stack
+
+    Set_flag(B, 0);
+    Set_flag(U, 1);
+    Set_flag(I, 1);                  // Disable further interrupts
     write(STACK_BASE + sp, status);  // Push the processor status onto the stack
     sp--;
 
     addr_abs = NMI_VECTOR;  // The non-maskable interrupt vector is located at
                             // 0xFFFA and 0xFFFB
-    uint16_t lo =
-        read(addr_abs +
-             0);  // Read the low byte of the non-maskable interrupt vector
-    uint16_t hi =
-        read(addr_abs +
-             1);  // Read the high byte of the non-maskable interrupt vector
+    uint16_t lo = read(addr_abs + 0);  // Read the low byte of the non-maskable interrupt vector
+    uint16_t hi = read(addr_abs + 1);  // Read the high byte of the non-maskable interrupt vector
     pc = (hi << 8) | lo;  // Set the program counter to the address specified by
                           // the non-maskable interrupt vector
 
@@ -392,82 +376,82 @@ uint8_t RP2A03::fetch() { // Helper function to fetch data
 
 // **LOAD/STORE INSTRUCTIONS**
 
-uint8_t RP2A03::LDA() noexcept { // Load Accumulator
+uint8_t RP2A03::LDA() noexcept {  // Load Accumulator
     fetch();
     a = fetched;
-    SetFlag(Z, a == 0x00);
-    SetFlag(N, a & 0x80);
+    Set_flag(Z, a == 0x00);
+    Set_flag(N, a & 0x80);
     return 1;
 }
 
-uint8_t RP2A03::LDX() noexcept { // Load X Register
+uint8_t RP2A03::LDX() noexcept {  // Load X Register
     fetch();
     x = fetched;
-    SetFlag(Z, x == 0x00);
-    SetFlag(N, x & 0x80);
+    Set_flag(Z, x == 0x00);
+    Set_flag(N, x & 0x80);
     return 1;
 }
 
-uint8_t RP2A03::LDY() noexcept { // Load Y Register
+uint8_t RP2A03::LDY() noexcept {  // Load Y Register
     fetch();
     y = fetched;
-    SetFlag(Z, y == 0x00);
-    SetFlag(N, y & 0x80);
+    Set_flag(Z, y == 0x00);
+    Set_flag(N, y & 0x80);
     return 1;
 }
 
-uint8_t RP2A03::STA() noexcept { // Store Accumulator
+uint8_t RP2A03::STA() noexcept {  // Store Accumulator
     write(addr_abs, a);
     return 0;
 }
 
-uint8_t RP2A03::STX() noexcept { // Store X Register
+uint8_t RP2A03::STX() noexcept {  // Store X Register
     write(addr_abs, x);
     return 0;
 }
 
-uint8_t RP2A03::STY() noexcept { // Store Y Register
+uint8_t RP2A03::STY() noexcept {  // Store Y Register
     write(addr_abs, y);
     return 0;
 }
 
-uint8_t RP2A03::TAX() noexcept { // Transfer Accumulator to X
+uint8_t RP2A03::TAX() noexcept {  // Transfer Accumulator to X
     x = a;
-    SetFlag(Z, x == 0x00);
-    SetFlag(N, x & 0x80);
+    Set_flag(Z, x == 0x00);
+    Set_flag(N, x & 0x80);
     return 0;
 }
 
-uint8_t RP2A03::TAY() noexcept { // Transfer Accumulator to Y
+uint8_t RP2A03::TAY() noexcept {  // Transfer Accumulator to Y
     y = a;
-    SetFlag(Z, y == 0x00);
-    SetFlag(N, y & 0x80);
+    Set_flag(Z, y == 0x00);
+    Set_flag(N, y & 0x80);
     return 0;
 }
 
-uint8_t RP2A03::TSX() noexcept { // Transfer Stack Pointer to X
+uint8_t RP2A03::TSX() noexcept {  // Transfer Stack Pointer to X
     x = sp;
-    SetFlag(Z, x == 0x00);
-    SetFlag(N, x & 0x80);
+    Set_flag(Z, x == 0x00);
+    Set_flag(N, x & 0x80);
     return 0;
 }
 
-uint8_t RP2A03::TXA() noexcept { // Transfer X to Accumulator
+uint8_t RP2A03::TXA() noexcept {  // Transfer X to Accumulator
     a = x;
-    SetFlag(Z, a == 0x00);
-    SetFlag(N, a & 0x80);
+    Set_flag(Z, a == 0x00);
+    Set_flag(N, a & 0x80);
     return 0;
 }
 
-uint8_t RP2A03::TXS() noexcept { // Transfer X to Stack Pointer
+uint8_t RP2A03::TXS() noexcept {  // Transfer X to Stack Pointer
     sp = x;
     return 0;
 }
 
-uint8_t RP2A03::TYA() noexcept { // Transfer Y to Accumulator
+uint8_t RP2A03::TYA() noexcept {  // Transfer Y to Accumulator
     a = y;
-    SetFlag(Z, a == 0x00);
-    SetFlag(N, a & 0x80);
+    Set_flag(Z, a == 0x00);
+    Set_flag(N, a & 0x80);
     return 0;
 }
 
@@ -498,13 +482,13 @@ uint8_t RP2A03::ADC() noexcept {
     */
 
     fetch();
-    temp = (uint16_t)a + (uint16_t)fetched + (uint16_t)GetFlag(C);
-    SetFlag(C, temp > 0x00FF);        // Set Carry flag if result exceeds 8 bits
-    SetFlag(Z, (temp & 0x00FF) == 0); // Set Zero flag if result is zero
-    SetFlag(N, temp & 0x0080);          // Set Negative flag if result's highest bit is set to 1
-    SetFlag(V, (~((uint16_t)a ^ (uint16_t)fetched) & ((uint16_t)a ^ (uint16_t)temp)) & 0x0080);
-                                      // Set Overflow flag based on the conditions described above
-    a = temp & 0x00FF;                // Store the result back in the accumulator (only the lower 8 bits)
+    temp = (uint16_t)a + (uint16_t)fetched + (uint16_t)get_flag(C);
+    Set_flag(C, temp > 0x00FF);         // Set Carry flag if result exceeds 8 bits
+    Set_flag(Z, (temp & 0x00FF) == 0);  // Set Zero flag if result is zero
+    Set_flag(N, temp & 0x0080);         // Set Negative flag if result's highest bit is set to 1
+    Set_flag(V, (~((uint16_t)a ^ (uint16_t)fetched) & ((uint16_t)a ^ (uint16_t)temp)) & 0x0080);
+                                        // Set Overflow flag based on the conditions described above
+    a = temp & 0x00FF;                  // Store the result back in the accumulator (only the lower 8 bits)
     return 1;  // Potentially add an additional clock cycle if page boundary is crossed
 }
 
@@ -516,36 +500,36 @@ uint8_t RP2A03::SBC() noexcept {
     //                            = A + (~M + 1) - 1 + C
     //                            = A + (~M) + C
     fetch();
-    uint16_t value = ((uint16_t)fetched) ^ 0x00FF; // Invert the bits of the fetched value for subtraction
-    temp = (uint16_t)a + value + (uint16_t)GetFlag(C); // Add the inverted value and the carry flag to the accumulator
-    SetFlag(C, temp > 0x00FF);        // Set Carry flag if result exceeds 8 bits (indicates no borrow)
-    SetFlag(Z, (temp & 0x00FF) == 0); // Set Zero flag if result is zero
-    SetFlag(N, temp & 0x0080);          // Set Negative flag if result's highest bit is set to 1
-    SetFlag(V, (((uint16_t)a ^ value) & ((uint16_t)a ^ temp)) & 0x0080);
-                                      // Set Overflow flag based on the conditions for subtraction
-    a = temp & 0x00FF;                // Store the result back in the accumulator (only the lower 8 bits)
+    uint16_t value = ((uint16_t)fetched) ^ 0x00FF;      // Invert the bits of the fetched value for subtraction
+    temp = (uint16_t)a + value + (uint16_t)get_flag(C); // Add the inverted value and the carry flag to the accumulator
+    Set_flag(C, temp > 0x00FF);        // Set Carry flag if result exceeds 8 bits (indicates no borrow)
+    Set_flag(Z, (temp & 0x00FF) == 0); // Set Zero flag if result is zero
+    Set_flag(N, temp & 0x0080);        // Set Negative flag if result's highest bit is set to 1
+    Set_flag(V, (((uint16_t)a ^ value) & ((uint16_t)a ^ temp)) & 0x0080);
+                                       // Set Overflow flag based on the conditions for subtraction
+    a = temp & 0x00FF;                 // Store the result back in the accumulator (only the lower 8 bits)
     return 1;  // Potentially add an additional clock cycle if page boundary is crossed
 }
 
-uint8_t RP2A03::ASL() noexcept { // Arithmetic Shift Left
+uint8_t RP2A03::ASL() noexcept {  // Arithmetic Shift Left
     fetch();
     temp = (uint16_t)fetched << 1;
-    SetFlag(C, (temp & 0xFF00) > 0);     // Set Carry flag if the highest bit of the original value is 1 (indicates a shift out of the byte)
-    SetFlag(Z, (temp & 0x00FF) == 0x00); // Set Zero flag if result is zero
-    SetFlag(N, temp & 0x0080);           // Set Negative flag if result's highest bit is set to 1
+    Set_flag(C, (temp & 0xFF00) > 0);      // Set Carry flag if the highest bit of the original value is 1 (indicates a shift out of the byte)
+    Set_flag(Z, (temp & 0x00FF) == 0x00);  // Set Zero flag if result is zero
+    Set_flag(N, temp & 0x0080);            // Set Negative flag if result's highest bit is set to 1
     if (lookup[opcode].addrmode == &RP2A03::IMP || lookup[opcode].addrmode == &RP2A03::ACC)
-        a = temp & 0x00FF;               // If the instruction operates on the accumulator, store the result back in the accumulator
+        a = temp & 0x00FF;                // If the instruction operates on the accumulator, store the result back in the accumulator
     else
         write(addr_abs, temp & 0x00FF);
     return 0;
 }
 
-uint8_t RP2A03::LSR() noexcept { // Logical Shift Right
+uint8_t RP2A03::LSR() noexcept {  // Logical Shift Right
     fetch();
-    SetFlag(C, fetched & 0x0001);
+    Set_flag(C, fetched & 0x0001);
     temp = fetched >> 1;
-    SetFlag(Z, (temp & 0x00FF) == 0x0000);
-    SetFlag(N, temp & 0x0080);
+    Set_flag(Z, (temp & 0x00FF) == 0x0000);
+    Set_flag(N, temp & 0x0080);
     if (lookup[opcode].addrmode == &RP2A03::IMP || lookup[opcode].addrmode == &RP2A03::ACC)
         a = temp & 0x00FF;
     else
@@ -553,16 +537,16 @@ uint8_t RP2A03::LSR() noexcept { // Logical Shift Right
     return 0;
 }
 
-uint8_t RP2A03::ROL() noexcept { // Rotate Left
+uint8_t RP2A03::ROL() noexcept {  // Rotate Left
     // Rotate Left shifts all bits to the left
     // The lowest bit is filled with the value of the Carry flag
     // The highest bit is moved into the Carry flag
     // E.g. 0b10110011 C = 0 ==> ROL ==> 0b01100110 C = 1
     fetch();
-    temp = (uint16_t)(fetched << 1) | GetFlag(C);
-    SetFlag(C, temp & 0xFF00);
-    SetFlag(Z, (temp & 0x00FF) == 0x0000);
-    SetFlag(N, temp & 0x0080);
+    temp = (uint16_t)(fetched << 1) | get_flag(C);
+    Set_flag(C, temp & 0xFF00);
+    Set_flag(Z, (temp & 0x00FF) == 0x0000);
+    Set_flag(N, temp & 0x0080);
     if (lookup[opcode].addrmode == &RP2A03::IMP || lookup[opcode].addrmode == &RP2A03::ACC)
         a = temp & 0x00FF;
     else
@@ -570,13 +554,13 @@ uint8_t RP2A03::ROL() noexcept { // Rotate Left
     return 0;
 }
 
-uint8_t RP2A03::ROR() noexcept { // Rotate Right
+uint8_t RP2A03::ROR() noexcept {  // Rotate Right
     // E.g. 0b10110011 C = 1 ==> ROR ==> 0b11011001 C = 1
     fetch();
-    temp = (uint16_t)(GetFlag(C) << 7) | (fetched >> 1);
-    SetFlag(C, fetched & 0x01);
-    SetFlag(Z, (temp & 0x00FF) == 0x00);
-    SetFlag(N, temp & 0x0080);
+    temp = (uint16_t)(get_flag(C) << 7) | (fetched >> 1);
+    Set_flag(C, fetched & 0x01);
+    Set_flag(Z, (temp & 0x00FF) == 0x00);
+    Set_flag(N, temp & 0x0080);
     if (lookup[opcode].addrmode == &RP2A03::IMP || lookup[opcode].addrmode == &RP2A03::ACC)
         a = temp & 0x00FF;
     else
@@ -584,123 +568,121 @@ uint8_t RP2A03::ROR() noexcept { // Rotate Right
     return 0;
 }
 
-uint8_t RP2A03::CMP() noexcept { // Compare Accumulator
+uint8_t RP2A03::CMP() noexcept {  // Compare Accumulator
     fetch();
-    temp = (uint16_t)a - (uint16_t)fetched; // Perform the subtraction to compare the values
-    SetFlag(C, a >= fetched);               // Set Carry flag if the accumulator is greater than or equal to the fetched value (indicates no borrow)
-    SetFlag(Z, (temp & 0x00FF) == 0x0000);  // Set Zero flag if the result of the comparison is zero (indicates equality)
-    SetFlag(N, temp & 0x0080); // Set Negative flag if the result's highest bit is set to 1 (indicates the accumulator is less than the fetched value)
+    temp = (uint16_t)a - (uint16_t)fetched;  // Perform the subtraction to compare the values
+    Set_flag(C, a >= fetched);               // Set Carry flag if the accumulator is greater than or equal to the fetched value (indicates no borrow)
+    Set_flag(Z, (temp & 0x00FF) == 0x0000);  // Set Zero flag if the result of the comparison is zero (indicates equality)
+    Set_flag(N, temp & 0x0080);  // Set Negative flag if the result's highest bit is set to 1 (indicates the accumulator is less than the fetched value)
     return 1;
 }
 
-uint8_t RP2A03::CPX() noexcept { // Compare X Register
+uint8_t RP2A03::CPX() noexcept {  // Compare X Register
     fetch();
     temp = (uint16_t)x - (uint16_t)fetched;
-    SetFlag(C, x >= fetched);
-    SetFlag(Z, (temp & 0x00FF) == 0x0000);
-    SetFlag(N, temp & 0x0080);
+    Set_flag(C, x >= fetched);
+    Set_flag(Z, (temp & 0x00FF) == 0x0000);
+    Set_flag(N, temp & 0x0080);
     return 0;
 }
 
-uint8_t RP2A03::CPY() noexcept { // Compare Y Register
+uint8_t RP2A03::CPY() noexcept {  // Compare Y Register
     fetch();
     temp = (uint16_t)y - (uint16_t)fetched;
-    SetFlag(C, y >= fetched);
-    SetFlag(Z, (temp & 0x00FF) == 0x0000);
-    SetFlag(N, temp & 0x0080);
+    Set_flag(C, y >= fetched);
+    Set_flag(Z, (temp & 0x00FF) == 0x0000);
+    Set_flag(N, temp & 0x0080);
     return 0;
 }
 
-uint8_t RP2A03::DEC() noexcept { // Decrement Memory
+uint8_t RP2A03::DEC() noexcept {  // Decrement Memory
     fetch();
     temp = fetched - 1;
     write(addr_abs, temp & 0x00FF);
-    SetFlag(Z, (temp & 0x00FF) == 0x0000);
-    SetFlag(N, temp & 0x0080);
+    Set_flag(Z, (temp & 0x00FF) == 0x0000);
+    Set_flag(N, temp & 0x0080);
     return 0;
 }
 
-uint8_t RP2A03::DEX() noexcept { // Decrement X Register
+uint8_t RP2A03::DEX() noexcept {  // Decrement X Register
     x--;
-    SetFlag(Z, x == 0x00);
-    SetFlag(N, x & 0x80);
+    Set_flag(Z, x == 0x00);
+    Set_flag(N, x & 0x80);
     return 0;
 }
 
-uint8_t RP2A03::DEY() noexcept { // Decrement Y Register
+uint8_t RP2A03::DEY() noexcept {  // Decrement Y Register
     y--;
-    SetFlag(Z, y == 0x00);
-    SetFlag(N, y & 0x80);
+    Set_flag(Z, y == 0x00);
+    Set_flag(N, y & 0x80);
     return 0;
 }
 
 uint8_t RP2A03::AND() noexcept {  // Logical AND
     fetch();
     a &= fetched;
-    SetFlag(Z, a == 0x00);  // Set Zero flag if result is zero
-    SetFlag(N,
-            a & 0x80);  // Set Negative flag if result's highest bit is set to 1
-    return 1;  // Potentially add an additional clock cycle if page boundary is
-               // crossed
+    Set_flag(Z, a == 0x00);  // Set Zero flag if result is zero
+    Set_flag(N, a & 0x80);   // Set Negative flag if result's highest bit is set to 1
+    return 1;  // Potentially add an additional clock cycle if page boundary is crossed
 }
 
 uint8_t RP2A03::ORA() noexcept {  // Inclusive OR
     fetch();
     a = a | fetched;
-    SetFlag(Z, a == 0x00);
-    SetFlag(N, a & 0x80);
+    Set_flag(Z, a == 0x00);
+    Set_flag(N, a & 0x80);
     return 1;
 }
 
-uint8_t RP2A03::EOR() noexcept { // Exclusive OR
+uint8_t RP2A03::EOR() noexcept {  // Exclusive OR
     fetch();
     a = a ^ fetched;
-    SetFlag(Z, a == 0x00);
-    SetFlag(N, a & 0x80);
+    Set_flag(Z, a == 0x00);
+    Set_flag(N, a & 0x80);
     return 1;
 }
 
-uint8_t RP2A03::INC() noexcept { // Increment Memory
+uint8_t RP2A03::INC() noexcept {  // Increment Memory
     fetch();
     temp = fetched + 1;
     write(addr_abs, temp & 0x00FF);
-    SetFlag(Z, (temp & 0x00FF) == 0x0000);
-    SetFlag(N, temp & 0x0080);
+    Set_flag(Z, (temp & 0x00FF) == 0x0000);
+    Set_flag(N, temp & 0x0080);
     return 0;
 }
 
-uint8_t RP2A03::INX() noexcept { // Increment X Register
+uint8_t RP2A03::INX() noexcept {  // Increment X Register
     x++;
-    SetFlag(Z, x == 0x00);
-    SetFlag(N, x & 0x80);
+    Set_flag(Z, x == 0x00);
+    Set_flag(N, x & 0x80);
     return 0;
 }
 
-uint8_t RP2A03::INY() noexcept { // Increment Y Register
+uint8_t RP2A03::INY() noexcept {  // Increment Y Register
     y++;
-    SetFlag(Z, y == 0x00);
-    SetFlag(N, y & 0x80);
+    Set_flag(Z, y == 0x00);
+    Set_flag(N, y & 0x80);
     return 0;
 }
 
 // **BRANCH INSTRUCTIONS**
 // Each returns an additional clock cycle if branch is taken
 
-uint8_t RP2A03::BCS() noexcept { // Branch if Carry Set
-    if (GetFlag(C) == 1) {
+uint8_t RP2A03::BCS() noexcept {  // Branch if Carry Set
+    if (get_flag(C) == 1) {
         cycles++;
         addr_abs = pc + addr_rel;
 
         if ((addr_abs & 0xFF00) != (pc & 0xFF00))
-            cycles++;   // Add an additional clock cycle if page boundary is crossed
+            cycles++;  // Add an additional clock cycle if page boundary is crossed
 
         pc = addr_abs;
     }
     return 0;
 }
 
-uint8_t RP2A03::BCC() noexcept { // Branch if Carry Clear
-    if (GetFlag(C) == 0) {
+uint8_t RP2A03::BCC() noexcept {  // Branch if Carry Clear
+    if (get_flag(C) == 0) {
         cycles++;
         addr_abs = pc + addr_rel;
 
@@ -712,8 +694,8 @@ uint8_t RP2A03::BCC() noexcept { // Branch if Carry Clear
     return 0;
 }
 
-uint8_t RP2A03::BEQ() noexcept { // Branch if Equal (Zero Set)
-    if (GetFlag(Z) == 1) {
+uint8_t RP2A03::BEQ() noexcept {  // Branch if Equal (Zero Set)
+    if (get_flag(Z) == 1) {
         cycles++;
         addr_abs = pc + addr_rel;
 
@@ -725,8 +707,8 @@ uint8_t RP2A03::BEQ() noexcept { // Branch if Equal (Zero Set)
     return 0;
 }
 
-uint8_t RP2A03::BNE() noexcept { // Branch if Not Equal (Zero Clear)
-    if (GetFlag(Z) == 0) {
+uint8_t RP2A03::BNE() noexcept {  // Branch if Not Equal (Zero Clear)
+    if (get_flag(Z) == 0) {
         cycles++;
         addr_abs = pc + addr_rel;
 
@@ -738,8 +720,8 @@ uint8_t RP2A03::BNE() noexcept { // Branch if Not Equal (Zero Clear)
     return 0;
 }
 
-uint8_t RP2A03::BMI() noexcept { // Branch if Minus (Negative Set)
-    if (GetFlag(N) == 1) {
+uint8_t RP2A03::BMI() noexcept {  // Branch if Minus (Negative Set)
+    if (get_flag(N) == 1) {
         cycles++;
         addr_abs = pc + addr_rel;
 
@@ -751,8 +733,8 @@ uint8_t RP2A03::BMI() noexcept { // Branch if Minus (Negative Set)
     return 0;
 }
 
-uint8_t RP2A03::BPL() noexcept { // Branch if Plus (Negative Clear)
-    if (GetFlag(N) == 0) {
+uint8_t RP2A03::BPL() noexcept {  // Branch if Plus (Negative Clear)
+    if (get_flag(N) == 0) {
         cycles++;
         addr_abs = pc + addr_rel;
 
@@ -764,8 +746,8 @@ uint8_t RP2A03::BPL() noexcept { // Branch if Plus (Negative Clear)
     return 0;
 }
 
-uint8_t RP2A03::BVS() noexcept { // Branch if Overflow Set
-    if (GetFlag(V) == 1) {
+uint8_t RP2A03::BVS() noexcept {  // Branch if Overflow Set
+    if (get_flag(V) == 1) {
         cycles++;
         addr_abs = pc + addr_rel;
 
@@ -777,8 +759,8 @@ uint8_t RP2A03::BVS() noexcept { // Branch if Overflow Set
     return 0;
 }
 
-uint8_t RP2A03::BVC() noexcept { // Branch if Overflow Clear
-    if (GetFlag(V) == 0) {
+uint8_t RP2A03::BVC() noexcept {  // Branch if Overflow Clear
+    if (get_flag(V) == 0) {
         cycles++;
         addr_abs = pc + addr_rel;
 
@@ -790,12 +772,12 @@ uint8_t RP2A03::BVC() noexcept { // Branch if Overflow Clear
     return 0;
 }
 
-uint8_t RP2A03::JMP() noexcept { // Jump to New Location 
+uint8_t RP2A03::JMP() noexcept {  // Jump to New Location 
     pc = addr_abs;
     return 0;
 }
 
-uint8_t RP2A03::JSR() noexcept { // Jump to Subroutine
+uint8_t RP2A03::JSR() noexcept {  // Jump to Subroutine
     // When a JSR instruction is executed, the processor pushes the address of the 
     // next instruction (the return address) onto the stack before jumping to the subroutine.
     pc--;
@@ -812,113 +794,113 @@ uint8_t RP2A03::JSR() noexcept { // Jump to Subroutine
 // **FLAG INSTRUCTIONS**
 // Each of these instructions set or clear a specific processor status flag
 
-uint8_t RP2A03::CLC() noexcept { // Clear Carry Flag
-    SetFlag(C, false);
+uint8_t RP2A03::CLC() noexcept {  // Clear Carry Flag
+    Set_flag(C, false);
     return 0;
 }
 
-uint8_t RP2A03::CLD() noexcept { // Clear Decimal Mode
-    SetFlag(D, false);
+uint8_t RP2A03::CLD() noexcept {  // Clear Decimal Mode
+    Set_flag(D, false);
     return 0;
 }
 
-uint8_t RP2A03::CLI() noexcept { // Clear Interrupt Disable
-    SetFlag(I, false);
+uint8_t RP2A03::CLI() noexcept {  // Clear Interrupt Disable
+    Set_flag(I, false);
     return 0;
 }
 
-uint8_t RP2A03::CLV() noexcept { // Clear Overflow Flag
-    SetFlag(V, false);
+uint8_t RP2A03::CLV() noexcept {  // Clear Overflow Flag
+    Set_flag(V, false);
     return 0;
 }
 
-uint8_t RP2A03::SEC() noexcept { // Set Carry Flag
-    SetFlag(C, true);
+uint8_t RP2A03::SEC() noexcept {  // Set Carry Flag
+    Set_flag(C, true);
     return 0;
 }
 
-uint8_t RP2A03::SED() noexcept { // Set Decimal Flag
-    SetFlag(D, true);
+uint8_t RP2A03::SED() noexcept {  // Set Decimal Flag
+    Set_flag(D, true);
     return 0;
 }
 
-uint8_t RP2A03::SEI() noexcept { // Set Interrupt Disable
-    SetFlag(I, true);
+uint8_t RP2A03::SEI() noexcept {  // Set Interrupt Disable
+    Set_flag(I, true);
     return 0;
 }
 
-uint8_t RP2A03::BIT() noexcept { // Test Bits in Memory with Accumulator
+uint8_t RP2A03::BIT() noexcept {  // Test Bits in Memory with Accumulator
     fetch();
     temp = a & fetched;
-    SetFlag(Z, (temp & 0x00FF) == 0x00); // Set Zero flag if result is zero
-    SetFlag(N, fetched & (1 << 7));      // Set Negative flag based on the highest bit of the fetched value
-    SetFlag(V, fetched & (1 << 6));      // Set Overflow flag based on the 6th bit of the fetched value
+    Set_flag(Z, (temp & 0x00FF) == 0x00);  // Set Zero flag if result is zero
+    Set_flag(N, fetched & (1 << 7));       // Set Negative flag based on the highest bit of the fetched value
+    Set_flag(V, fetched & (1 << 6));       // Set Overflow flag based on the 6th bit of the fetched value
     return 0;
 }
 
 // **STACK INSTRUCTIONS**
 // Each of these instructions manipulate the stack pointer and/or the stack
 
-uint8_t RP2A03::PHA() noexcept { // Push Accumulator
-    write(STACK_BASE + sp, a); // The stack is located in the memory range 0x0100 to 0x01FF
+uint8_t RP2A03::PHA() noexcept {  // Push Accumulator
+    write(STACK_BASE + sp, a);    // The stack is located in the memory range 0x0100 to 0x01FF
     sp--;
     return 0;
 }
 
-uint8_t RP2A03::PLA() noexcept { // Pop Accumulator
+uint8_t RP2A03::PLA() noexcept {  // Pop Accumulator
     sp++;
     a = read(STACK_BASE + sp);
-    SetFlag(Z, a == 0x00);  // Set Zero flag if result is zero
-    SetFlag(N, a & 0x0080); // Set Negative flag if result's highest bit is set to 1
+    Set_flag(Z, a == 0x00);   // Set Zero flag if result is zero
+    Set_flag(N, a & 0x0080);  // Set Negative flag if result's highest bit is set to 1
     return 0;
 }
 
-uint8_t RP2A03::PHP() noexcept { // Push Processor Status
+uint8_t RP2A03::PHP() noexcept {  // Push Processor Status
     write(STACK_BASE + sp, status | B | U);
-    SetFlag(B, 1);
-    SetFlag(U, 1);
+    Set_flag(B, 1);
+    Set_flag(U, 1);
     sp--;
     return 0;
 }
 
-uint8_t RP2A03::PLP() noexcept { // Pop Processor Status
+uint8_t RP2A03::PLP() noexcept {  // Pop Processor Status
     sp++;
     status = read(STACK_BASE + sp);
-    SetFlag(U, 1);
+    Set_flag(U, 1);
     return 0;
 }
 
 // **INTERRUPT INSTRUCTIONS**
 
-uint8_t RP2A03::RTI() noexcept { // Return from Interrupt
+uint8_t RP2A03::RTI() noexcept {  // Return from Interrupt
     sp++;
-    status = read(STACK_BASE + sp); // Pull the processor status from the stack
-    SetFlag(B, 0);                  // Clear the Break flag
-    SetFlag(U, 1);                  // Set the unused flag to 1 (it is always set to 1)
+    status = read(STACK_BASE + sp);  // Pull the processor status from the stack
+    Set_flag(B, 0);                  // Clear the Break flag
+    Set_flag(U, 1);                  // Set the unused flag to 1 (it is always set to 1)
     
     sp++;
-    uint16_t lo = read(STACK_BASE + sp); // Pull the low byte of the program counter from the stack
+    uint16_t lo = read(STACK_BASE + sp);  // Pull the low byte of the program counter from the stack
     sp++;
-    uint16_t hi = read(STACK_BASE + sp); // Pull the high byte of the program counter from the stack
+    uint16_t hi = read(STACK_BASE + sp);  // Pull the high byte of the program counter from the stack
     pc = (hi << 8) | lo;
     
     return 0;
 }
 
-uint8_t RP2A03::RTS() noexcept { // Return from Subroutine
+uint8_t RP2A03::RTS() noexcept {  // Return from Subroutine
     sp++;
-    uint16_t lo = read(STACK_BASE + sp); // Pull the low byte of the return address from the stack
+    uint16_t lo = read(STACK_BASE + sp);  // Pull the low byte of the return address from the stack
     sp++;
-    uint16_t hi = read(STACK_BASE + sp); // Pull the high byte of the return address from the stack
-    pc = ((hi << 8) | lo) + 1;           // Set the program counter to the return address (add 1 to point to the next instruction after the JSR)
+    uint16_t hi = read(STACK_BASE + sp);  // Pull the high byte of the return address from the stack
+    pc = ((hi << 8) | lo) + 1;            // Set the program counter to the return address (add 1 to point to the next instruction after the JSR)
     
     return 0;
 }
 
-uint8_t RP2A03::BRK() noexcept { // Force Interrupt
+uint8_t RP2A03::BRK() noexcept {  // Force Interrupt
     pc++;
 
-    SetFlag(I, 1); // Set Interrupt Disable flag to prevent further interrupts
+    Set_flag(I, 1);  // Set Interrupt Disable flag to prevent further interrupts
     write(STACK_BASE + sp, (pc >> 8) & 0x00FF);
     sp--;
     write(STACK_BASE + sp, pc & 0x00FF);

--- a/src/core/RP2A03.h
+++ b/src/core/RP2A03.h
@@ -15,22 +15,22 @@ public:
         // The NES uses a variant of the 6502 (the 2A03) which has no
         // hardware support for decimal mode, so we won't emulate that
         // flag here (it would be a useless flag in the context of the NES)
-        C = (1 << 0), // Carry Bit
-        Z = (1 << 1), // Zero
-        I = (1 << 2), // Disable Interrupts
-        D = (1 << 3), // Decimal Mode (unused in this implementation)
-        B = (1 << 4), // Break
-        U = (1 << 5), // Unused
-        V = (1 << 6), // Overflow
-        N = (1 << 7), // Negative
+        C = (1 << 0),  // Carry Bit
+        Z = (1 << 1),  // Zero
+        I = (1 << 2),  // Disable Interrupts
+        D = (1 << 3),  // Decimal Mode (unused in this implementation)
+        B = (1 << 4),  // Break
+        U = (1 << 5),  // Unused
+        V = (1 << 6),  // Overflow
+        N = (1 << 7),  // Negative
     };
 
-    uint8_t  x{0x00};      // X Register
-    uint8_t  y{0x00};      // Y Register
-    uint8_t  a{0x00};      // Accumulator Register
-    uint8_t  sp{0x00};     // Stack Pointer (points to location on bus)
-    uint16_t pc{0x0000};   // Program Counter
-    uint8_t  status{0x00}; // Status Register
+    uint8_t  x{0x00};       // X Register
+    uint8_t  y{0x00};       // Y Register
+    uint8_t  a{0x00};       // Accumulator Register
+    uint8_t  sp{0x00};      // Stack Pointer (points to location on bus)
+    uint16_t pc{0x0000};    // Program Counter
+    uint8_t  status{0x00};  // Status Register
 
     constexpr static uint16_t STACK_BASE{0x0100};      // Stack starts at 0x0100 and grows downwards
     constexpr static uint16_t RESET_VECTOR{0xFFFC};    // Reset vector is located at 0xFFFC and 0xFFFD
@@ -55,13 +55,13 @@ public:
         ROL, ROR, RTI, RTS, 
         SBC, SEC, SED, SEI, STA, STX, STY, 
         TAX, TAY, TSX, TXA, TXS, TYA, 
-        XXX,  // Illegal opcode
-        COUNT // Total number of mnemonics (used for validation)
+        XXX,   // Illegal opcode
+        COUNT  // Total number of mnemonics (used for validation)
     };
 
     enum class DEBUG_ADDRESSING_MODE : uint8_t {
         IMP, ACC, IMM, ZP0, ZPX, ZPY, REL, ABS, ABX, ABY, IND, IZX, IZY, 
-        COUNT // Total number of addressing modes (used for validation)
+        COUNT  // Total number of addressing modes (used for validation)
     };
 
     struct INSTRUCTION {
@@ -73,19 +73,19 @@ public:
     };
 
     // Addressing modes
-    uint8_t IMP() noexcept; // Implied
-    uint8_t ACC() noexcept; // Accumulator
-    uint8_t IMM() noexcept; // Immediate
-    uint8_t ZP0() noexcept; // Zero Page
-    uint8_t ZPX() noexcept; // Zero Page,X
-    uint8_t ZPY() noexcept; // Zero Page,Y
-    uint8_t REL() noexcept; // Relative
-    uint8_t ABS() noexcept; // Absolute
-    uint8_t ABX() noexcept; // Absolute,X
-    uint8_t ABY() noexcept; // Absolute,Y
-    uint8_t IND() noexcept; // Indirect
-    uint8_t IZX() noexcept; // Indirect,X
-    uint8_t IZY() noexcept; // Indirect,Y
+    uint8_t IMP() noexcept;  // Implied
+    uint8_t ACC() noexcept;  // Accumulator
+    uint8_t IMM() noexcept;  // Immediate
+    uint8_t ZP0() noexcept;  // Zero Page
+    uint8_t ZPX() noexcept;  // Zero Page,X
+    uint8_t ZPY() noexcept;  // Zero Page,Y
+    uint8_t REL() noexcept;  // Relative
+    uint8_t ABS() noexcept;  // Absolute
+    uint8_t ABX() noexcept;  // Absolute,X
+    uint8_t ABY() noexcept;  // Absolute,Y
+    uint8_t IND() noexcept;  // Indirect
+    uint8_t IZX() noexcept;  // Indirect,X
+    uint8_t IZY() noexcept;  // Indirect,Y
 
     // Opcodes
     uint8_t ADC() noexcept;  uint8_t AND() noexcept;
@@ -117,21 +117,21 @@ public:
     uint8_t TSX() noexcept;  uint8_t TXA() noexcept;
     uint8_t TXS() noexcept;  uint8_t TYA() noexcept;
 
-    uint8_t XXX() noexcept; // Illegal opcode
+    uint8_t XXX() noexcept;  // Illegal opcode
 
-    void    clock(); // Perform one clock cycle
-    void    reset(); // Reset the CPU to initial state
-    void    irq();   // Interrupt request
-    void    nmi();   // Non-maskable interrupt request
+    void    clock();  // Perform one clock cycle
+    void    reset();  // Reset the CPU to initial state
+    void    irq();    // Interrupt request
+    void    nmi();    // Non-maskable interrupt request
 
-    uint8_t     fetch();          // Fetch data from memory (based on addressing mode)
-    uint8_t     fetched{0x00};    // Represents the working input value to the ALU
-    uint16_t    temp{0x0000};     // Convenience variable used everywhere
+    uint8_t     fetch();           // Fetch data from memory (based on addressing mode)
+    uint8_t     fetched{0x00};     // Represents the working input value to the ALU
+    uint16_t    temp{0x0000};      // Convenience variable used everywhere
 
-    uint16_t    addr_abs{0x0000}; // Absolute address after all calculations
-    uint16_t    addr_rel{0x0000}; // Relative address for branch instructions
-    uint8_t     opcode{0x00};     // Current opcode
-    uint8_t     cycles{0};        // Cycles remaining for current instruction
+    uint16_t    addr_abs{0x0000};  // Absolute address after all calculations
+    uint16_t    addr_rel{0x0000};  // Relative address for branch instructions
+    uint8_t     opcode{0x00};      // Current opcode
+    uint8_t     cycles{0};         // Cycles remaining for current instruction
 
 private:
     Bus* bus{nullptr};
@@ -141,8 +141,8 @@ private:
     inline void     write(uint16_t addr, uint8_t data) noexcept;
 
     // get flag & set flag (just for convenience)
-    inline uint8_t  GetFlag(FLAGS6502 flag) const noexcept;
-    inline void     SetFlag(FLAGS6502 flag, bool value) noexcept;
+    inline uint8_t  get_flag(FLAGS6502 flag) const noexcept;
+    inline void     Set_flag(FLAGS6502 flag, bool value) noexcept;
 
     std::array<INSTRUCTION, 256> lookup;
 };


### PR DESCRIPTION
This pull request primarily focuses on improving code consistency and clarity in the `RP2A03` CPU emulation and related files. The main changes include renaming methods for flag manipulation to use a consistent snake_case style, updating all usages accordingly, and making minor naming improvements elsewhere. Additionally, the Catch2 test framework version has been updated.

**Code consistency and naming improvements:**

* Renamed all instances of `GetFlag` and `SetFlag` to `get_flag` and `Set_flag` in `RP2A03.cpp` to follow a consistent snake_case naming convention. All usages throughout the CPU instruction implementations and interrupt handlers were updated to match the new names. [[1]](diffhunk://#diff-4366773ddd0d2e2b1acfac061afc2181a32f26b535c363efde8cf9f801f89a02L45-R46) [[2]](diffhunk://#diff-4366773ddd0d2e2b1acfac061afc2181a32f26b535c363efde8cf9f801f89a02L108-R124) [[3]](diffhunk://#diff-4366773ddd0d2e2b1acfac061afc2181a32f26b535c363efde8cf9f801f89a02L144-R151) [[4]](diffhunk://#diff-4366773ddd0d2e2b1acfac061afc2181a32f26b535c363efde8cf9f801f89a02L398-R399) [[5]](diffhunk://#diff-4366773ddd0d2e2b1acfac061afc2181a32f26b535c363efde8cf9f801f89a02L436-R442) [[6]](diffhunk://#diff-4366773ddd0d2e2b1acfac061afc2181a32f26b535c363efde8cf9f801f89a02L469-R454) [[7]](diffhunk://#diff-4366773ddd0d2e2b1acfac061afc2181a32f26b535c363efde8cf9f801f89a02L501-R489) [[8]](diffhunk://#diff-4366773ddd0d2e2b1acfac061afc2181a32f26b535c363efde8cf9f801f89a02L520-R508) [[9]](diffhunk://#diff-4366773ddd0d2e2b1acfac061afc2181a32f26b535c363efde8cf9f801f89a02L533-R519) [[10]](diffhunk://#diff-4366773ddd0d2e2b1acfac061afc2181a32f26b535c363efde8cf9f801f89a02L545-R532) [[11]](diffhunk://#diff-4366773ddd0d2e2b1acfac061afc2181a32f26b535c363efde8cf9f801f89a02L562-R549) [[12]](diffhunk://#diff-4366773ddd0d2e2b1acfac061afc2181a32f26b535c363efde8cf9f801f89a02L576-R563) [[13]](diffhunk://#diff-4366773ddd0d2e2b1acfac061afc2181a32f26b535c363efde8cf9f801f89a02L590-R672) [[14]](diffhunk://#diff-4366773ddd0d2e2b1acfac061afc2181a32f26b535c363efde8cf9f801f89a02L703-R685) [[15]](diffhunk://#diff-4366773ddd0d2e2b1acfac061afc2181a32f26b535c363efde8cf9f801f89a02L716-R698) [[16]](diffhunk://#diff-4366773ddd0d2e2b1acfac061afc2181a32f26b535c363efde8cf9f801f89a02L729-R711) [[17]](diffhunk://#diff-4366773ddd0d2e2b1acfac061afc2181a32f26b535c363efde8cf9f801f89a02L742-R724) [[18]](diffhunk://#diff-4366773ddd0d2e2b1acfac061afc2181a32f26b535c363efde8cf9f801f89a02L755-R737)
* Changed the parameter name from `bReadOnly` to `bus_read_only` in the `Bus::read` method declaration in `Bus.h` for improved clarity and consistency.

**Dependency updates:**

* Updated the Catch2 unit testing framework from version `v3.5.2` to `v3.14.0` in `CMakeLists.txt`.

**Minor formatting and cleanup:**

* Cleaned up code formatting in interrupt handlers and reset logic for better readability, without changing functionality. [[1]](diffhunk://#diff-4366773ddd0d2e2b1acfac061afc2181a32f26b535c363efde8cf9f801f89a02L88-R88) [[2]](diffhunk://#diff-4366773ddd0d2e2b1acfac061afc2181a32f26b535c363efde8cf9f801f89a02L108-R124) [[3]](diffhunk://#diff-4366773ddd0d2e2b1acfac061afc2181a32f26b535c363efde8cf9f801f89a02L144-R151)

These changes collectively enhance code readability, maintainability, and ensure a more uniform coding style across the CPU emulation codebase.