### PR TITLE
Update CMake configuration and add SDL3/ImGui support with caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Setup SDL3
+        uses: libsdl-org/setup-sdl@main
+        id: sdl
+        with:
+          install-linux-dependencies: true
+          version: 3-latest
+          version-sdl-image: 3-latest
+
       - name: Cache CMake deps
         uses: actions/cache@v5
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,16 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Cache CMake deps
+        uses: actions/cache@v5
+        with:
+          path: |
+            build/_deps
+            ~/.cache/CMake
+          key: ${{ runner.os }}-cmake-${{ hashFiles('CMakeLists.txt', 'cmake/**/*.cmake', '.github/workflows/*.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-cmake-
+
       - name: Configure
         run: cmake -S . -B build -DNEMU_ENABLE_TESTS=OFF
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 4.2)
 project(Nemu LANGUAGES CXX)
 
 # Set C++ standard
@@ -18,12 +18,62 @@ if (CMAKE_GENERATOR STREQUAL "Ninja")
     message(STATUS "Ninja build system detected.")
 endif()
 
-# Main executable
-add_executable(Nemu src/main.cpp src/core/Bus.cpp src/core/RP2A03.cpp src/utils/Disassembler.cpp)
-
-# Testing
 include(FetchContent)
 
+# ----------------------------
+# SDL3
+# ----------------------------
+find_package(SDL3 REQUIRED)
+
+# ----------------------------
+# Dear ImGui
+# ----------------------------
+FetchContent_Declare(
+    imgui
+    GIT_REPOSITORY https://github.com/ocornut/imgui.git
+    GIT_TAG v1.92.7
+)
+FetchContent_GetProperties(imgui)
+
+FetchContent_MakeAvailable(imgui)
+
+# ImGui static library
+add_library(imgui STATIC
+    ${imgui_SOURCE_DIR}/imgui.cpp
+    ${imgui_SOURCE_DIR}/imgui_draw.cpp
+    ${imgui_SOURCE_DIR}/imgui_tables.cpp
+    ${imgui_SOURCE_DIR}/imgui_widgets.cpp
+    ${imgui_SOURCE_DIR}/imgui_demo.cpp
+
+    ${imgui_SOURCE_DIR}/backends/imgui_impl_sdl3.cpp
+    ${imgui_SOURCE_DIR}/backends/imgui_impl_opengl3.cpp
+)
+
+target_include_directories(imgui PUBLIC
+    ${imgui_SOURCE_DIR}
+    ${imgui_SOURCE_DIR}/backends
+)
+
+target_link_libraries(imgui PUBLIC SDL3::SDL3)
+
+# ----------------------------
+# OpenGL
+# ----------------------------
+find_package(OpenGL REQUIRED)
+
+# ----------------------------
+# Main executable
+# ----------------------------
+add_executable(Nemu
+    src/gui/gui_main.cpp 
+    src/core/Bus.cpp 
+    src/core/RP2A03.cpp 
+    src/utils/Disassembler.cpp
+)
+
+# ----------------------------
+# Testing
+# ----------------------------
 FetchContent_Declare(
     Catch2
     GIT_REPOSITORY https://github.com/catchorg/Catch2.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 4.2)
+cmake_minimum_required(VERSION 3.31)
 project(Nemu LANGUAGES CXX)
 
 # Set C++ standard

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,12 @@ add_executable(Nemu
     src/utils/Disassembler.cpp
 )
 
+target_link_libraries(Nemu PRIVATE
+    imgui
+    SDL3::SDL3
+    OpenGL::GL
+)
+
 # ----------------------------
 # Testing
 # ----------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ include(FetchContent)
 # ----------------------------
 # SDL3
 # ----------------------------
-find_package(SDL3 REQUIRED)
+find_package(SDL3 REQUIRED CONFIG)
 
 # ----------------------------
 # Dear ImGui

--- a/src/gui/gui_main.cpp
+++ b/src/gui/gui_main.cpp
@@ -1,0 +1,10 @@
+#include <SDL3/SDL.h>
+#include <SDL3/SDL_opengl.h>
+
+#include "backends/imgui_impl_opengl3.h"
+#include "backends/imgui_impl_sdl3.h"
+#include "imgui.h"
+
+int main(int argc, char const *argv[]) {
+    
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,8 +1,0 @@
-// main.cpp
-#include <iostream>
-
-int main()
-{
-    std::cout << "Hello, modern C++ world!" << std::endl;
-    return 0;
-}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 # CMake configuration for tests
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.31)
 
 add_executable(test_main 
     test_main.cpp 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,12 @@
 # CMake configuration for tests
 cmake_minimum_required(VERSION 3.16)
 
-add_executable(test_main test_main.cpp ../src/core/Bus.cpp ../src/core/RP2A03.cpp ../src/utils/Disassembler.cpp)
+add_executable(test_main 
+    test_main.cpp 
+    ../src/core/Bus.cpp 
+    ../src/core/RP2C02.cpp 
+    ../src/core/RP2A03.cpp 
+    ../src/utils/Disassembler.cpp)
 
 # Link Catch2 to the test executable
 target_link_libraries(test_main PRIVATE Catch2::Catch2WithMain)


### PR DESCRIPTION
This pull request introduces significant changes to the project build and structure, primarily to add support for a new GUI using SDL3 and Dear ImGui, and to improve build efficiency with CMake caching. The main application entry point has shifted from a simple console program to a new GUI-based structure, and dependencies are now managed more robustly via CMake's `FetchContent` and `find_package`. Additionally, the test build has been updated to include a missing source file.

**Build system and dependency management improvements:**

* Added CMake caching to the GitHub Actions workflow to speed up dependency management by caching `build/_deps` and CMake's cache directory. (.github/workflows/build.yml)
* Updated CMake minimum required version to 4.2 and restructured `CMakeLists.txt` to use `FetchContent` for managing dependencies like Dear ImGui and Catch2, and to use `find_package` for SDL3 and OpenGL. (CMakeLists.txt) [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL1-R1) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR21-R76)

**GUI and application structure changes:**

* Replaced the previous console-based `main.cpp` with a new GUI entry point in `src/gui/gui_main.cpp`, initializing the project for SDL3 and Dear ImGui integration. (src/main.cpp, src/gui/gui_main.cpp) [[1]](diffhunk://#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2L1-L8) [[2]](diffhunk://#diff-0c3f5a76f9f6ff0ef103574da251d5d055e3a8955f6d3d50c2ef7ebfe480ab6dR1-R10)
* Updated the main executable target in `CMakeLists.txt` to use the new GUI source file and link against the freshly added ImGui and SDL3 dependencies. (CMakeLists.txt)

**Testing improvements:**

* Modified the test executable in `tests/CMakeLists.txt` to include `RP2C02.cpp`, ensuring all necessary core components are tested. (tests/CMakeLists.txt)